### PR TITLE
Feat add extensions

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -4,14 +4,14 @@ A portable notational velocity for your shell written in POSIX shell.
 
 video::https://user-images.githubusercontent.com/96259932/223130698-f870c17c-f307-40c0-b48f-050173bf3d18.mp4[options=autoplay]
 
-== Feauteres
+== Features
 
 * Removes cognitive load by combining the note creation and note searching
-* Customizable (use your preffered fuzzy finder or file picker; see link:docs/tested-pickers.adoc[tested pickers])
-* Uses wather editor you want (even link:docs/visual-studio-code.adoc[Visual Studio Code])
+* Customizable (use your preferred fuzzy finder or file picker; see link:docs/tested-pickers.adoc[tested pickers])
+* Uses whatever editor you want (even link:docs/visual-studio-code.adoc[Visual Studio Code])
 * Portable (runs on every POSIX compatible OS, see link:docs/tested-oses.adoc[Tested OSes])
 * Minimal (only a POSIX shell and the picker of your choice)
-* Unintrusive (use markdown by default, but works also with your preferred markup languages such as: https://orgmode.org/[org], https://github.com/nvim-neorg/neorg[neorg], rest, https://asciidoc.org/[adoc], etc)
+* Nonintrusive (use markdown by default, but works also with your preferred markup languages such as: https://orgmode.org/[org], https://github.com/nvim-neorg/neorg[neorg], rest, https://asciidoc.org/[adoc], etc)
 
 == Dependencies
 
@@ -48,7 +48,7 @@ shv [yesterday | ye | y] <label> # edit yesterday diary note
 
 ==== no subcommand
 
-Grepes all the files with your selected extention in your `$SHV_PATH`. If no match is found, or you use the keybinding to create a note, a new note will be created.
+`grep` all the files with your selected extension in your `$SHV_PATH`. If no match is found, or you use the keybinding to create a note, a new note will be created.
 
 ==== tags
 
@@ -60,7 +60,7 @@ Searches in your `$SHV_DIARY_PATH` for notes, and uses your picker to select wha
 
 ==== yesterday, today and tomorrow
 
-Get the corresponding daily note assosiated with the day. If passed a `label` that label will be prepended to the filename with an `_` character.
+Get the corresponding daily note associated with the day. If passed a `label` that label will be prepended to the filename with an `_` character.
 
 [,bash]
 ----
@@ -95,7 +95,7 @@ export SHV_TAG_EXPR="#[a-z0-9_]+"
 # For see how to modify this value check 'man date'
 export SHV_DATE_FMT="%Y-%m-%d"
 
-# Exention used for the notes
+# Extension used for the notes
 export SHV_EXT="md"
 
 # Picker used to select notes

--- a/shv
+++ b/shv
@@ -8,6 +8,7 @@ set -e
 : "${SHV_PATH:=$HOME/Documents/notes}"
 : "${SHV_DIARY_PATH:=$SHV_PATH/diary}"
 : "${SHV_EXT:=md}"
+: "${SHV_MORE_EXTS:=adoc txt org taskpaper}"
 : "${SHV_TAG_EXPR:=#[a-z0-9_]+}"
 : "${SHV_DATE_FMT:=%Y-%m-%d}"
 : "${SHV_AUTO_CD:=true}"
@@ -51,11 +52,16 @@ _format() {
 # List files in dir
 
 _get_files() {
+    files=""
+    for file in $SHV_EXT $SHV_MORE_EXTS; do
+        files="${files:+${files} -o} -iname *.${file}"
+    done
+
     find "$1" \
-        -type f \
-        -name "*.$SHV_EXT" \
-        -not -path "./.obsidian/*" \
-        -not -path "./.git/*"
+         -type f \
+         '(' $files ')' \
+         -not -path "./.obsidian/*" \
+         -not -path "./.git/*"
 }
 
 # List markdown tags in SHV_PATH

--- a/shv
+++ b/shv
@@ -7,8 +7,8 @@ set -e
 : "${SHV_PICKER:="fzf --ansi --print-query --bind=alt-enter:print-query"}"
 : "${SHV_PATH:=$HOME/Documents/notes}"
 : "${SHV_DIARY_PATH:=$SHV_PATH/diary}"
-: "${SHV_EXT:=md}"
-: "${SHV_MORE_EXTS:=adoc txt org taskpaper}"
+: "${SHV_EXTS:=md txt org}"
+: "${SHV_EXT:=$(echo "$SHV_EXTS" | cut -d' ' -f1)}"
 : "${SHV_TAG_EXPR:=#[a-z0-9_]+}"
 : "${SHV_DATE_FMT:=%Y-%m-%d}"
 : "${SHV_AUTO_CD:=true}"
@@ -52,14 +52,14 @@ _format() {
 # List files in dir
 
 _get_files() {
-    files=""
-    for file in $SHV_EXT $SHV_MORE_EXTS; do
-        files="${files:+${files} -o} -iname *.${file}"
+    query=""
+    for ext in $SHV_EXTS; do
+        query="${query:+${query} -o} -iname *.${ext}"
     done
 
     find "$1" \
          -type f \
-         '(' $files ')' \
+         '(' $query ')' \
          -not -path "./.obsidian/*" \
          -not -path "./.git/*"
 }


### PR DESCRIPTION
This PR fixes the English spelling of some words in the readme. It also adds support for a new variable - `SHV_MORE_EXTS`. This variable allows the user to add additional extensions to the fuzzy finder, essentially supporting any number of legacy text documents. New docs are still created using the `SHV_EXT` extension.