### PR TITLE
Fixing $journal_path

### DIFF
--- a/docs/shv.adoc
+++ b/docs/shv.adoc
@@ -88,6 +88,9 @@ The script is configured and customized through enviroment variables.
 
   export SHV_IGNORE="./.git/* ./pdfs/*"
 
+*SHV_NORMALIZE_CH*::
+// documentation missing  
+
 *SHV_PATH*::
   path to notes (default: `$XDG_DATA_HOME/notes`)
 

--- a/docs/shv.adoc
+++ b/docs/shv.adoc
@@ -88,9 +88,6 @@ The script is configured and customized through enviroment variables.
 
   export SHV_IGNORE="./.git/* ./pdfs/*"
 
-*SHV_NORMALIZE_CH*::
-// documentation missing  
-
 *SHV_PATH*::
   path to notes (default: `$XDG_DATA_HOME/notes`)
 

--- a/shv
+++ b/shv
@@ -7,7 +7,7 @@ auto_cd=${SHV_AUTO_CD:-"true"}
 ext=${SHV_EXT:-"md"}
 date_fmt=${SHV_DATE_FMT:-"%Y-%m-%d"}
 ignore=${SHV_IGNORE:-"./.obsidian/* ./.git/* ./*.pdf"}
-journal_path=${SHV_DIARY_PATH:-"$SHV_PATH"}
+journal_path=${SHV_JOURNAL_PATH:-"$SHV_PATH"}
 path=${SHV_PATH:-${XDG_DATA_HOME:-${HOME}/.local/share}/notes}
 picker=${SHV_PICKER:-"fzf -m --ansi --print-query --bind=alt-enter:print-query"}
 subcmd=${SHV_DEFAULT_CMD:-"select"}


### PR DESCRIPTION
Thanks for a great little tool, just what I was looking for.

When testing the journal subcommands, `$SHV_JOURNAL_PATH` was not being applied; I think it is due to a vestigial `$SHV_DIARY_PATH`.

Also, `$SHV_NORMALIZE_CH` is currently undocumented.